### PR TITLE
Add stub C++ engine and setup docs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "cpp_engine"]
-	path = cpp_engine
-	url = https://github.com/jadenfix/financial_cpp.git

--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# Trading Website Demo
+
+This repo contains a small demo app with a React frontend, a Node/Express backend and a native addon built with `node-gyp`.
+
+## Prerequisites
+
+- Node.js 18+
+- npm
+- A running MongoDB instance (local or remote)
+
+## Installation
+
+1. Install dependencies for each part:
+
+```bash
+cd backend && npm install
+cd ../frontend && npm install
+cd ../addon && npm install  # optional: builds the native addon
+```
+
+2. Copy `backend/.env.example` to `backend/.env` and adjust values if necessary.
+
+3. Start MongoDB locally (`docker run --rm -p 27017:27017 mongo`) or point `MONGO_URI` to another instance.
+
+## Running
+
+In separate terminals run:
+
+```bash
+cd backend && npm run dev
+```
+
+```bash
+cd frontend && npm run dev
+```
+
+The frontend dev server proxies API requests to the backend on port `8000` by default.
+
+## Notes
+
+The `cpp_engine` folder contains minimal stub implementations so the optional native addon compiles. It does not perform any trading logic.

--- a/addon/binding.gyp
+++ b/addon/binding.gyp
@@ -3,7 +3,7 @@
     {
       "target_name": "financialAddon",
       "sources": [
-        "src/addon.cpp",
+        "addon.cpp",
         "../cpp_engine/src/Portfolio.cpp",
         "../cpp_engine/src/DataManager.cpp",
         "../cpp_engine/src/PortfolioManager.cpp"

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,5 @@
+# Example environment for backend
+MONGO_URI=mongodb://localhost:27017/trading-website
+JWT_SECRET=change_me
+JWT_EXPIRES_IN=1h
+PORT=8000

--- a/cpp_engine/include/Portfolio.h
+++ b/cpp_engine/include/Portfolio.h
@@ -1,0 +1,23 @@
+#ifndef PORTFOLIO_H
+#define PORTFOLIO_H
+#include <string>
+
+struct StrategyResult {
+    double total_return_pct;
+    double max_drawdown_pct;
+    double realized_pnl;
+    double total_commission;
+    int    num_fills;
+    double final_equity;
+};
+
+class Portfolio {
+public:
+    explicit Portfolio(double initialCash = 0.0);
+    StrategyResult get_results_summary() const;
+    static double runBacktest(const std::string& symbol, int lookbackDays);
+private:
+    double cash;
+};
+
+#endif // PORTFOLIO_H

--- a/cpp_engine/src/DataManager.cpp
+++ b/cpp_engine/src/DataManager.cpp
@@ -1,0 +1,7 @@
+// Placeholder implementation for DataManager
+#include <string>
+
+class DataManager {
+public:
+    void load(const std::string& /*path*/) {}
+};

--- a/cpp_engine/src/Portfolio.cpp
+++ b/cpp_engine/src/Portfolio.cpp
@@ -1,0 +1,18 @@
+#include "../include/Portfolio.h"
+
+Portfolio::Portfolio(double initialCash) : cash(initialCash) {}
+
+StrategyResult Portfolio::get_results_summary() const {
+    StrategyResult res{};
+    res.total_return_pct = 0.0;
+    res.max_drawdown_pct = 0.0;
+    res.realized_pnl = 0.0;
+    res.total_commission = 0.0;
+    res.num_fills = 0;
+    res.final_equity = cash;
+    return res;
+}
+
+double Portfolio::runBacktest(const std::string& /*symbol*/, int lookbackDays) {
+    return static_cast<double>(lookbackDays);
+}

--- a/cpp_engine/src/PortfolioManager.cpp
+++ b/cpp_engine/src/PortfolioManager.cpp
@@ -1,0 +1,6 @@
+#include "../include/Portfolio.h"
+
+class PortfolioManager {
+public:
+    Portfolio run(const Portfolio& p) { return p; }
+};


### PR DESCRIPTION
## Summary
- replace missing `cpp_engine` submodule with minimal stub sources
- fix addon path in `binding.gyp`
- provide example backend environment file
- add repository README with setup instructions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fbe96b3bc832c9e77705557bd578a